### PR TITLE
[Wiki] Add message of the day functionality

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -115,5 +115,8 @@
       }
     }
   },
-  "defaultProject": "teammates"
+  "defaultProject": "teammates",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -264,6 +264,8 @@ public final class Const {
         public static final String INSTRUCTORS = URI_PREFIX + "/instructors";
         public static final String INSTRUCTOR = URI_PREFIX + "/instructor";
         public static final String INSTRUCTOR_PRIVILEGE = URI_PREFIX + "/instructor/privilege";
+        public static final String MOTD = URI_PREFIX + "/motd";
+        public static final String PREVMOTD = URI_PREFIX + "/prevmotd";
         public static final String RESULT = URI_PREFIX + "/result";
         public static final String STUDENTS = URI_PREFIX + "/students";
         public static final String STUDENT = URI_PREFIX + "/student";

--- a/src/main/java/teammates/ui/constants/ResourceEndpoints.java
+++ b/src/main/java/teammates/ui/constants/ResourceEndpoints.java
@@ -24,6 +24,8 @@ public enum ResourceEndpoints {
     INSTRUCTORS(ResourceURIs.INSTRUCTORS),
     INSTRUCTOR(ResourceURIs.INSTRUCTOR),
     INSTRUCTOR_PRIVILEGE(ResourceURIs.INSTRUCTOR_PRIVILEGE),
+    MOTD(ResourceURIs.MOTD),
+    PREVMOTD(ResourceURIs.PREVMOTD),
     RESULT(ResourceURIs.RESULT),
     STUDENTS(ResourceURIs.STUDENTS),
     STUDENT(ResourceURIs.STUDENT),

--- a/src/main/java/teammates/ui/output/MotdData.java
+++ b/src/main/java/teammates/ui/output/MotdData.java
@@ -1,0 +1,43 @@
+package teammates.ui.output;
+
+import javax.annotation.Nullable;
+
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.common.util.StringHelper;
+
+/**
+ * The API output format of {@link GetMotd}.
+ */
+public class MotdData extends ApiOutput {
+    private final String motd;
+    private final String date;
+
+    public MotdData(String userInfoType) {
+        System.out.println("userinfo type");
+        System.out.println(userInfoType);
+        // ideally, we'd be able to store the MotDs somewhere (message + date sent)
+        switch(userInfoType) {
+            case "admin": 
+                this.motd = "Admins: Please make a new instructor in /web/admin/home to test things out!";
+                this.date = "Posted on 29/2/2021";
+                break;
+            case "student": 
+                this.motd = "Students: Please remember to update your TEAMMATES feedback for your project team!";
+                this.date = "Posted on 26/2/2021";
+                break;
+            case "instructor": 
+                this.motd = "Instructors: Please remember to send the email to your students for TEAMMATES feedback!";
+                this.date = "Posted on 23/2/2021";
+                break;
+            default: 
+                this.motd = "";
+                this.date = "";
+                break;
+        };
+    }
+
+    public String getMotd() {
+        return this.motd;
+    }
+}

--- a/src/main/java/teammates/ui/output/MotdData.java
+++ b/src/main/java/teammates/ui/output/MotdData.java
@@ -1,11 +1,5 @@
 package teammates.ui.output;
 
-import javax.annotation.Nullable;
-
-import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
-import teammates.common.datatransfer.questions.FeedbackResponseDetails;
-import teammates.common.util.StringHelper;
-
 /**
  * The API output format of {@link GetMotd}.
  */
@@ -14,30 +8,32 @@ public class MotdData extends ApiOutput {
     private final String date;
 
     public MotdData(String userInfoType) {
-        System.out.println("userinfo type");
-        System.out.println(userInfoType);
         // ideally, we'd be able to store the MotDs somewhere (message + date sent)
         switch(userInfoType) {
-            case "admin": 
-                this.motd = "Admins: Please make a new instructor in /web/admin/home to test things out!";
-                this.date = "Posted on 29/2/2021";
-                break;
-            case "student": 
-                this.motd = "Students: Please remember to update your TEAMMATES feedback for your project team!";
-                this.date = "Posted on 26/2/2021";
-                break;
-            case "instructor": 
-                this.motd = "Instructors: Please remember to send the email to your students for TEAMMATES feedback!";
-                this.date = "Posted on 23/2/2021";
-                break;
-            default: 
-                this.motd = "";
-                this.date = "";
-                break;
-        };
+        case "admin":
+            this.motd = "Admins: Please make a new instructor in /web/admin/home to test things out!";
+            this.date = "Posted on 29/2/2021";
+            break;
+        case "student":
+            this.motd = "Students: Please remember to update your TEAMMATES feedback for your project team!";
+            this.date = "Posted on 26/2/2021";
+            break;
+        case "instructor":
+            this.motd = "Instructors: Please remember to send the email to your students for TEAMMATES feedback!";
+            this.date = "Posted on 23/2/2021";
+            break;
+        default:
+            this.motd = "";
+            this.date = "";
+            break;
+        }
     }
 
     public String getMotd() {
         return this.motd;
+    }
+
+    public String getDate() {
+        return this.date;
     }
 }

--- a/src/main/java/teammates/ui/output/PrevMotdData.java
+++ b/src/main/java/teammates/ui/output/PrevMotdData.java
@@ -1,0 +1,43 @@
+package teammates.ui.output;
+
+import javax.annotation.Nullable;
+
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.common.util.StringHelper;
+
+/**
+ * The API output format of {@link GetPrevMotd}.
+ */
+public class PrevMotdData extends ApiOutput {
+    private final String motdList[];
+    private final String dateList[];
+
+    public PrevMotdData(String userInfoType) {
+        System.out.println("userinfo type");
+        System.out.println(userInfoType);
+        // ideally, we'd be able to store the MotDs somewhere (message + date sent)
+        switch(userInfoType) {
+            case "admin": 
+                this.motdList = new String[]{ "Admins: Please make a new instructor in /web/admin/home to test things out!", "Admins: New website is up!" };
+                this.dateList = new String[]{ "Posted on 29/2/2021", "Posted on 28/2/2021" };
+                break;
+            case "student": 
+                this.motdList = new String[]{ "Students: Please remember to update your TEAMMATES feedback for your project team!", "Students: Please remember to sign up for courses." };
+                this.dateList = new String[]{ "Posted on 26/2/2021", "Posted on 28/2/2021" };
+                break;
+            case "instructor": 
+                this.motdList = new String[]{ "Instructors: Please remember to send the email to your students for TEAMMATES feedback!", "Instructors: Please update your courses soon." };
+                this.dateList = new String[]{ "Posted on 23/2/2021", "Posted on 28/2/2021" };
+                break;
+            default: 
+                this.motdList = new String[]{};
+                this.dateList = new String[]{};
+                break;
+        };
+    }
+
+    public String[] getPrevMotd() {
+        return this.motdList;
+    }
+}

--- a/src/main/java/teammates/ui/output/PrevMotdData.java
+++ b/src/main/java/teammates/ui/output/PrevMotdData.java
@@ -1,43 +1,42 @@
 package teammates.ui.output;
 
-import javax.annotation.Nullable;
-
-import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
-import teammates.common.datatransfer.questions.FeedbackResponseDetails;
-import teammates.common.util.StringHelper;
-
 /**
  * The API output format of {@link GetPrevMotd}.
  */
 public class PrevMotdData extends ApiOutput {
-    private final String motdList[];
-    private final String dateList[];
+    private final String[] motdList;
+    private final String[] dateList;
 
     public PrevMotdData(String userInfoType) {
-        System.out.println("userinfo type");
-        System.out.println(userInfoType);
         // ideally, we'd be able to store the MotDs somewhere (message + date sent)
         switch(userInfoType) {
-            case "admin": 
-                this.motdList = new String[]{ "Admins: Please make a new instructor in /web/admin/home to test things out!", "Admins: New website is up!" };
-                this.dateList = new String[]{ "Posted on 29/2/2021", "Posted on 28/2/2021" };
-                break;
-            case "student": 
-                this.motdList = new String[]{ "Students: Please remember to update your TEAMMATES feedback for your project team!", "Students: Please remember to sign up for courses." };
-                this.dateList = new String[]{ "Posted on 26/2/2021", "Posted on 28/2/2021" };
-                break;
-            case "instructor": 
-                this.motdList = new String[]{ "Instructors: Please remember to send the email to your students for TEAMMATES feedback!", "Instructors: Please update your courses soon." };
-                this.dateList = new String[]{ "Posted on 23/2/2021", "Posted on 28/2/2021" };
-                break;
-            default: 
-                this.motdList = new String[]{};
-                this.dateList = new String[]{};
-                break;
-        };
+        case "admin":
+            this.motdList = new String[] { "Admins: Please make a new instructor in /web/admin/home to test things out!",
+                    "Admins: New website is up!" };
+            this.dateList = new String[] { "Posted on 29/2/2021", "Posted on 28/2/2021" };
+            break;
+        case "student":
+            this.motdList = new String[] { "Students: Please remember to update your TEAMMATES"
+                        + "feedback for your project team!", "Students: Please remember to sign up for courses." };
+            this.dateList = new String[] { "Posted on 26/2/2021", "Posted on 28/2/2021" };
+            break;
+        case "instructor":
+            this.motdList = new String[] { "Instructors: Please remember to send the email to "
+                        + "your students for TEAMMATES feedback!", "Instructors: Please update your courses soon." };
+            this.dateList = new String[] { "Posted on 23/2/2021", "Posted on 28/2/2021" };
+            break;
+        default:
+            this.motdList = new String[] {};
+            this.dateList = new String[] {};
+            break;
+        }
     }
 
     public String[] getPrevMotd() {
         return this.motdList;
+    }
+
+    public String[] getPrevMotdDate() {
+        return this.dateList;
     }
 }

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -118,6 +118,10 @@ public class ActionFactory {
         map(ResourceURIs.INSTRUCTOR, PUT, UpdateInstructorAction.class);
         map(ResourceURIs.INSTRUCTOR, POST, CreateInstructorAction.class);
 
+        // motd
+        map(ResourceURIs.MOTD, GET, GetMotdAction.class);
+        map(ResourceURIs.PREVMOTD, GET, GetPrevMotdAction.class);
+
         // Cron jobs; use GET request
         // Reference: https://cloud.google.com/appengine/docs/standard/java/config/cron
 

--- a/src/main/java/teammates/ui/webapi/GetMotdAction.java
+++ b/src/main/java/teammates/ui/webapi/GetMotdAction.java
@@ -1,0 +1,65 @@
+package teammates.ui.webapi;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.ui.output.InstructorData;
+import teammates.ui.output.InstructorsData;
+import teammates.ui.output.MotdData;
+import teammates.ui.request.Intent;
+
+/**
+ * Gets the Message of the Day, depending on the userInfo (Daniel)
+ */
+class GetMotdAction extends Action {
+
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    void checkSpecificAccessControl() {
+        // check if atleast student / instructor / admin
+        if (userInfo.isAdmin || userInfo.isStudent || userInfo.isInstructor) {
+            return;
+        } else {
+            throw new UnauthorizedAccessException("Not authorized");
+        }
+    }
+
+    // sends a request to server to get MotD, depending on the userInfo type
+    @Override
+    JsonResult execute() {
+        // get the userInfo type as a string
+        String userInfoType = null;
+        if (userInfo.isAdmin) {
+            userInfoType = "admin";
+        } else if (userInfo.isStudent) {
+            userInfoType = "student";
+        } else if (userInfo.isInstructor) {
+            userInfoType = "instructor";
+        }
+        
+        // debug print statements to show that this userInfo may not be working as intended when testing
+        System.out.println("admin / student / instructor");
+        System.out.println(userInfo.isAdmin);
+        System.out.println(userInfo.isStudent);
+        System.out.println(userInfo.isInstructor);
+
+        if (userInfoType != null) {
+            // use MotdData
+            MotdData data = new MotdData(userInfoType);
+            return new JsonResult(data);
+        } else {
+            return new JsonResult("Please Login to see Message of the Day");
+        }
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/GetMotdAction.java
+++ b/src/main/java/teammates/ui/webapi/GetMotdAction.java
@@ -1,21 +1,10 @@
 package teammates.ui.webapi;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.InstructorAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.UnauthorizedAccessException;
-import teammates.common.util.Const;
-import teammates.common.util.StringHelper;
-import teammates.ui.output.InstructorData;
-import teammates.ui.output.InstructorsData;
 import teammates.ui.output.MotdData;
-import teammates.ui.request.Intent;
 
 /**
- * Gets the Message of the Day, depending on the userInfo (Daniel)
+ * Gets the Message of the Day, depending on the userInfo (Daniel).
  */
 class GetMotdAction extends Action {
 
@@ -46,19 +35,13 @@ class GetMotdAction extends Action {
         } else if (userInfo.isInstructor) {
             userInfoType = "instructor";
         }
-        
-        // debug print statements to show that this userInfo may not be working as intended when testing
-        System.out.println("admin / student / instructor");
-        System.out.println(userInfo.isAdmin);
-        System.out.println(userInfo.isStudent);
-        System.out.println(userInfo.isInstructor);
 
-        if (userInfoType != null) {
+        if (userInfoType == null) {
+            return new JsonResult("Please Login to see Message of the Day");
+        } else {
             // use MotdData
             MotdData data = new MotdData(userInfoType);
             return new JsonResult(data);
-        } else {
-            return new JsonResult("Please Login to see Message of the Day");
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GetPrevMotdAction.java
+++ b/src/main/java/teammates/ui/webapi/GetPrevMotdAction.java
@@ -1,0 +1,65 @@
+package teammates.ui.webapi;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.ui.output.InstructorData;
+import teammates.ui.output.InstructorsData;
+import teammates.ui.output.PrevMotdData;
+import teammates.ui.request.Intent;
+
+/**
+ * Gets the previous Message of the Days, depending on the userInfo (Daniel)
+ */
+class GetPrevMotdAction extends Action {
+
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    void checkSpecificAccessControl() {
+        // check if atleast student / instructor / admin
+        if (userInfo.isAdmin || userInfo.isStudent || userInfo.isInstructor) {
+            return;
+        } else {
+            throw new UnauthorizedAccessException("Not authorized");
+        }
+    }
+
+    // sends a request to server to get MotD, depending on the userInfo type
+    @Override
+    JsonResult execute() {
+        // get the userInfo type as a string
+        String userInfoType = null;
+        if (userInfo.isAdmin) {
+            userInfoType = "admin";
+        } else if (userInfo.isStudent) {
+            userInfoType = "student";
+        } else if (userInfo.isInstructor) {
+            userInfoType = "instructor";
+        }
+        
+        // debug print statements to show that this userInfo may not be working as intended when testing
+        System.out.println("admin / student / instructor");
+        System.out.println(userInfo.isAdmin);
+        System.out.println(userInfo.isStudent);
+        System.out.println(userInfo.isInstructor);
+
+        if (userInfoType != null) {
+            // use MotdData
+            PrevMotdData data = new PrevMotdData(userInfoType);
+            return new JsonResult(data);
+        } else {
+            return new JsonResult("Please Login to see Message of the Day");
+        }
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/GetPrevMotdAction.java
+++ b/src/main/java/teammates/ui/webapi/GetPrevMotdAction.java
@@ -1,21 +1,10 @@
 package teammates.ui.webapi;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.InstructorAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.UnauthorizedAccessException;
-import teammates.common.util.Const;
-import teammates.common.util.StringHelper;
-import teammates.ui.output.InstructorData;
-import teammates.ui.output.InstructorsData;
 import teammates.ui.output.PrevMotdData;
-import teammates.ui.request.Intent;
 
 /**
- * Gets the previous Message of the Days, depending on the userInfo (Daniel)
+ * Gets the previous Message of the Days, depending on the userInfo (Daniel).
  */
 class GetPrevMotdAction extends Action {
 
@@ -46,19 +35,13 @@ class GetPrevMotdAction extends Action {
         } else if (userInfo.isInstructor) {
             userInfoType = "instructor";
         }
-        
-        // debug print statements to show that this userInfo may not be working as intended when testing
-        System.out.println("admin / student / instructor");
-        System.out.println(userInfo.isAdmin);
-        System.out.println(userInfo.isStudent);
-        System.out.println(userInfo.isInstructor);
 
-        if (userInfoType != null) {
+        if (userInfoType == null) {
+            return new JsonResult("Please Login to see Message of the Day");
+        } else {
             // use MotdData
             PrevMotdData data = new PrevMotdData(userInfoType);
             return new JsonResult(data);
-        } else {
-            return new JsonResult("Please Login to see Message of the Day");
         }
     }
 

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -67,6 +67,14 @@
         <i class="fas fa-ban"></i>&nbsp;You are currently not enabling cookies in your browser. TEAMMATES requires cookies in order to work effectively.
       </div>
     </div>
+    <div id="motd" *ngIf="(isStudent || isInstructor || isAdmin) && !isMotdRead">
+      <div class="motd">
+        <div #motd [innerHtml]="motdHtml">
+        </div>
+        <button (click)="hideMotd()">X</button>
+        <div><a href="/web/front/motd">Previous Message of the Day</a></div>
+      </div>
+    </div>
     <div *ngIf="!isValidUser">
       <div *ngIf="isStudent || isInstructor || isAdmin">
         <div class="row">

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -110,3 +110,21 @@ nav {
   border: 1px solid rgba(255, 255, 255, .3);
   margin: .5rem 15px;
 }
+
+.motd {
+  font-size: inherit;
+  text-align: center;
+  background-color: rgb(240, 240, 240);
+}
+
+.motd h1 {
+  font-size: 2em;
+}
+
+.motd p {
+  font-size: 1.25em;
+}
+
+.motd a {
+  border-color: rgb(220, 220, 220);
+}

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -15,7 +15,9 @@ import { fromEvent, merge, Observable, of } from 'rxjs';
 import { mapTo } from 'rxjs/operators';
 import uaParser from 'ua-parser-js';
 import { environment } from '../environments/environment';
+import { MotdService } from '../services/motd.service';
 import { StatusMessageService } from '../services/status-message.service';
+import { Motd } from '../types/api-output';
 import { Toast } from './components/toast/toast';
 
 const DEFAULT_TITLE: string = 'TEAMMATES - Online Peer Feedback/Evaluation System for Student Team Projects';
@@ -42,6 +44,8 @@ export class PageComponent {
   @Input() hideAuthInfo: boolean = false;
   @Input() navItems: any[] = [];
   @Input() institute: string = '';
+  @Input() motdString: string = '';
+  @Input() motdHtml: string = '';
 
   isCollapsed: boolean = true;
   isUnsupportedBrowser: boolean = false;
@@ -69,7 +73,7 @@ export class PageComponent {
 
   constructor(private router: Router, private route: ActivatedRoute, private title: Title,
               private ngbModal: NgbModal, location: Location,
-              private statusMessageService: StatusMessageService) {
+              private statusMessageService: StatusMessageService, private motdService: MotdService) {
     this.checkBrowserVersion();
     this.router.events.subscribe((val: any) => {
       if (val instanceof NavigationEnd) {
@@ -104,7 +108,37 @@ export class PageComponent {
 
     this.statusMessageService.getToastEvent().subscribe((toast: Toast) => {
       this.toast = toast;
+    });    
+    
+    this.motdService.getMotd().subscribe((res: Motd) => {
+      if (res.motd) {
+        this.setMotd(res.motd, res.date);
+      }
     });
+  }
+
+  // motd
+  isMotdRead: boolean = (localStorage.getItem('isMotdRead') !== null && localStorage.getItem('isMotdRead') === 'true' ? true : false);
+  date: string = "";
+
+  private setMotd(motd: string, date: string): void {
+    if (!this.isMotdRead || motd == "") {
+      this.motdString = motd;
+      this.date = date;
+      this.motdHtml = 
+        "<h1>Message of the Day</h1>" + 
+        "<p>" + this.motdString + "</p>" + 
+        "<p>" + this.date + "</p>";
+    } else {
+      this.motdHtml = "";
+    }
+  }
+
+  hideMotd() {
+    document.getElementById('motd')!.style.visibility='hidden';
+    document.getElementById('motd')!.style.height='0px';
+    localStorage.setItem('isMotdRead', 'true');
+    console.log(localStorage.getItem('isMotdRead'));
   }
 
   private checkBrowserVersion(): void {

--- a/src/web/app/pages-admin/admin-page.component.ts
+++ b/src/web/app/pages-admin/admin-page.component.ts
@@ -12,6 +12,7 @@ import { AuthInfo } from '../../types/api-output';
   selector: 'tm-admin-page',
   templateUrl: './admin-page.component.html',
 })
+
 export class AdminPageComponent implements OnInit {
 
   user: string = '';
@@ -19,6 +20,7 @@ export class AdminPageComponent implements OnInit {
   isInstructor: boolean = false;
   isStudent: boolean = false;
   isAdmin: boolean = false;
+
   navItems: any[] = [
     {
       url: '/web/admin',

--- a/src/web/app/pages-static/motd-page/motd-page.component.html
+++ b/src/web/app/pages-static/motd-page/motd-page.component.html
@@ -1,0 +1,4 @@
+<div class="motd-wrapper">
+  <h1 class="color-orange">Message of the Day (s)</h1>
+  <div [innerHtml]="motd"></div>  
+</div>

--- a/src/web/app/pages-static/motd-page/motd-page.component.scss
+++ b/src/web/app/pages-static/motd-page/motd-page.component.scss
@@ -1,0 +1,35 @@
+.core-team-table {
+  margin-bottom: 20px;
+}
+
+.core-team-photo-cell,
+.core-team-details-cell {
+  border: 1px solid #EEE;
+  padding-bottom: 15px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 15px;
+
+  img {
+    width: 100px;
+  }
+}
+
+.core-team-details-cell {
+  min-width: 360px;
+  padding-right: 40px;
+}
+
+.motd-wrapper {
+  background-color: rgb(230, 230, 230);
+  padding: 2em;
+}
+
+.motd-wrapper h1 {
+  text-align: center;
+}
+
+.motd-wrapper p {
+  font-weight: bold;
+  font-size: 1.25em;
+}

--- a/src/web/app/pages-static/motd-page/motd-page.component.spec.ts
+++ b/src/web/app/pages-static/motd-page/motd-page.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { PageComponent } from '../../page.component';
+import { MotdPageComponent } from './motd-page.component';
+
+describe('MotdPageComponent', () => {
+  let component: MotdPageComponent;
+  let fixture: ComponentFixture<MotdPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        PageComponent,
+        MotdPageComponent],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MotdPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-static/motd-page/motd-page.component.ts
+++ b/src/web/app/pages-static/motd-page/motd-page.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { MotdService } from 'src/web/services/motd.service';
+import { PrevMotd } from 'src/web/types/api-output';
+
+/**
+ * Motd page.
+ */
+@Component({
+  selector: 'tm-motd-page',
+  templateUrl: './motd-page.component.html',
+  styleUrls: ['./motd-page.component.scss'],
+})
+export class MotdPageComponent implements OnInit {
+
+  constructor(private motdService: MotdService) {}
+
+  motd: string = "";
+
+  isMotdRead: boolean = true;
+
+  setMotdVisibility() {
+    document.getElementById('motd')!.style.visibility='hidden';
+    document.getElementById('motd')!.style.height='0px';
+  }
+
+  ngOnInit(): void {
+    
+    this.motdService.getPrevMotd().subscribe((res: PrevMotd) => {
+      for (let i = 0; i < res.dateList.length; i++) {
+        this.motd = this.motd.concat("<p>" + res.motdList[i] + "</p>" + "<p>" + res.dateList[i] + "</p>");
+      }
+      console.log(this.motd);
+    });
+    this.setMotdVisibility();
+  }
+
+}

--- a/src/web/app/pages-static/motd-page/motd-page.module.ts
+++ b/src/web/app/pages-static/motd-page/motd-page.module.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
+import { MotdPageComponent } from './motd-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: MotdPageComponent,
+  },
+];
+
+/**
+ * Module for motd page.
+ */
+@NgModule({
+  declarations: [
+    MotdPageComponent,
+  ],
+  exports: [
+    MotdPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    TeammatesRouterModule,
+  ],
+})
+export class MotdPageModule { }

--- a/src/web/app/pages-static/static-page.component.ts
+++ b/src/web/app/pages-static/static-page.component.ts
@@ -41,6 +41,10 @@ export class StaticPageComponent implements OnInit {
       display: 'Terms',
     },
     {
+      url: '/web/front/motd',
+      display: 'MotD',
+    },
+    {
       display: 'Help',
       children: [
         {

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -22,6 +22,10 @@ const routes: Routes = [
     loadChildren: () => import('./about-page/about-page.module').then((m: any) => m.AboutPageModule),
   },
   {
+    path: 'motd',
+    loadChildren: () => import('./motd-page/motd-page.module').then((m: any) => m.MotdPageModule),
+  },
+  {
     path: 'contact',
     loadChildren: () => import('./contact-page/contact-page.module').then((m: any) => m.ContactPageModule),
   },

--- a/src/web/app/pages-student/student-page.component.ts
+++ b/src/web/app/pages-student/student-page.component.ts
@@ -40,6 +40,7 @@ export class StudentPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.isFetchingAuthDetails = true;
+
     this.route.queryParams.subscribe((queryParams: any) => {
       this.authService.getAuthUser(queryParams.user).subscribe((res: AuthInfo) => {
         if (res.user) {

--- a/src/web/services/motd.service.ts
+++ b/src/web/services/motd.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ResourceEndpoints } from '../types/api-const';
+import { Motd, PrevMotd } from '../types/api-output';
+import { HttpRequestService } from './http-request.service';
+
+/**
+ * Handles getting of MotD.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class MotdService {
+  constructor(private httpRequestService: HttpRequestService) {}
+
+  /**
+   * Gets the message of the day.
+   */
+  getMotd(): Observable<Motd> {
+    return this.httpRequestService.get(ResourceEndpoints.MOTD);
+  }
+
+  /**
+   * Gets previous message of the day.
+   */
+  getPrevMotd(): Observable<PrevMotd> {
+    return this.httpRequestService.get(ResourceEndpoints.PREVMOTD);
+  }
+
+}


### PR DESCRIPTION
Fixes #

As per https://github.com/TEAMMATES/teammates/wiki/Message-of-the-Day, an improvement for TEAMMATES internship application is added in the form of a "Message of the Day".

**Outline of Solution**

<!-- Tell us how you solved the issue. -->

Added message of the day function (motd), which displays upon logging in and shows different messages depending on the user type (Administrator / Student / Instructor). Motd is rendered only if logged in. A button is provided to mark the Motd as "read", which will hide the motd.

This is done through Windows.localStorage, by keeping track of a key "isMotdRead". Improvement can be done in this by having the backend server keep track of whether or not a user has read a specific motd . If the user has read it, then the server does not send over the motd. This is for "A way for users to mark a MotD as 'read' by a user so that the same MotD is not shown to the user multiple times." in the wiki.

An anchor element is added to the motd message in the form of a link "Previous Message of the Day", which redirects to a page with previous motd messages. This for "A way for users to access past MotDs." in the wiki.

Different motd is given as per "A way to show different MotD to different user types." in the wiki, which is done by checking the userInfo and seeing whether or not the user is an Admin / Student / Instructor. The server sends different messages based on this. Right now the server sends the same motd, and proper storage will need to be implemented in order to store more motd.

<!-- If there are things you want the reviewers to focus on, include them here as well. -->

I have found an issue (?) during testing, where the userInfo returns true for both isStudent and isInstructor, which is documented in https://docs.google.com/document/d/1np0rf8JguZHWzob8WUrFPLQL5gtxrR6e3L4lVqj1Us8/edit?usp=sharing
